### PR TITLE
Fix background palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Many commands accept expressions as parameters; the expressions can contain the 
 ## Commands implemented so far
 
 ### `font`
-Loads a `.png` file containing the 8x8 font. Fonts will use palette #0.
+Loads a `.png` file containing the 8x8 font. Fonts will use palette #1.
 #### Positional parameters:
 * `fileName`: a string pointing to the `.png` file to use.
 #### Example:
@@ -79,7 +79,7 @@ Loads a `.png` file containing the 8x8 font. Fonts will use palette #0.
 Loads a image file named `"damieng.com - Hourglass font.png"` as a font.
 
 ### `background`
-Loads a `.png` file as a background image. If the image is not paletized with 16 colors, it will be automatically converted by the tool. Backgrounds will use palette #1.
+Loads a `.png` file as a background image. If the image is not paletized with 16 colors, it will be automatically converted by the tool. Backgrounds will use palette #0.
 #### Positional parameters:
 * `fileName`: a string pointing to the `.png` file to use.
 #### Example:
@@ -315,7 +315,7 @@ Tells that the window will start at position `29, 1` and have a width of `10` an
 Tells that the window will be located at the default position, with the default size.
 
 ### `cursor`
-Allows to configure the blinking text cursor. It uses the palette #0.
+Allows to configure the blinking text cursor. It uses the palette #1.
 
 #### Positional parameters:
 * `fileName`: name of the `.png` file containing the graphics of the cursor sprite;

--- a/base/src/vn_engine.c
+++ b/base/src/vn_engine.c
@@ -199,6 +199,7 @@ void VN_init() {
 	XGM_setLoopNumber(-1);
 	XGM_setForceDelayDMA(TRUE);
 
+	VDP_setTextPalette(TEXT_PAL);
 	VDP_drawText("choice4genesis v0.11.0", 17, 27);
 }
 

--- a/base/src/vn_engine.c
+++ b/base/src/vn_engine.c
@@ -212,7 +212,7 @@ void VN_showImage(const Image *image, VDPPlane plane, u16 palNum, u16 x, u16 y) 
 
 void VN_background(const Image *image) {
 	imageInfo.tileNumber = 256;
-	VN_showImage(image, BG_B, PAL1, 0, 0);
+	VN_showImage(image, BG_B, PAL0, 0, 0);
 }
 
 void VN_image(const Image *image, const u8 flags) {

--- a/base/src/vn_engine.c
+++ b/base/src/vn_engine.c
@@ -201,7 +201,7 @@ void VN_init() {
 	XGM_setForceDelayDMA(TRUE);
 
 	VDP_setTextPalette(TEXT_PAL);
-	VDP_drawText("choice4genesis v0.11.0", 17, 27);
+	VDP_drawText("choice4genesis v0.11.1", 17, 27);
 }
 
 

--- a/base/src/vn_engine.c
+++ b/base/src/vn_engine.c
@@ -9,6 +9,7 @@
 
 #define BACKGROUND_PAL PAL0
 #define TEXT_PAL PAL1
+#define IMAGE_PAL PAL2
 
 char textBuffer[TEXT_BUFFER_LEN];
 
@@ -220,8 +221,8 @@ void VN_background(const Image *image) {
 }
 
 void VN_image(const Image *image, const u8 flags) {
-	if (flags & LAYER_FOREGROUND) VN_showImage(image, BG_A, PAL2, imageInfo.x, imageInfo.y);
-	if (flags & LAYER_BACKGROUND) VN_showImage(image, BG_B, PAL2, imageInfo.x, imageInfo.y);
+	if (flags & LAYER_FOREGROUND) VN_showImage(image, BG_A, IMAGE_PAL, imageInfo.x, imageInfo.y);
+	if (flags & LAYER_BACKGROUND) VN_showImage(image, BG_B, IMAGE_PAL, imageInfo.x, imageInfo.y);
 }
 
 void VN_imageAt(u16 x, u16 y) {

--- a/base/src/vn_engine.c
+++ b/base/src/vn_engine.c
@@ -7,6 +7,9 @@
 
 #define PCM_CHANNEL (64)
 
+#define BACKGROUND_PAL PAL0
+#define TEXT_PAL PAL1
+
 char textBuffer[TEXT_BUFFER_LEN];
 
 struct {
@@ -212,7 +215,7 @@ void VN_showImage(const Image *image, VDPPlane plane, u16 palNum, u16 x, u16 y) 
 
 void VN_background(const Image *image) {
 	imageInfo.tileNumber = 256;
-	VN_showImage(image, BG_B, PAL0, 0, 0);
+	VN_showImage(image, BG_B, BACKGROUND_PAL, 0, 0);
 }
 
 void VN_image(const Image *image, const u8 flags) {
@@ -227,7 +230,7 @@ void VN_imageAt(u16 x, u16 y) {
 
 void VN_font(const Image *image) {
 	VDP_loadFont(image->tileset, DMA);
-	VDP_setPalette(PAL0, (u16*)image->palette->data);
+	VDP_setPalette(TEXT_PAL, (u16*)image->palette->data);
 }
 
 
@@ -248,7 +251,7 @@ void VN_stop(const u8 flags) {
 
 
 void VN_clearWindow() {
-	VDP_clearTextAreaEx(BG_A, TILE_ATTR_FULL(PAL0, FALSE, FALSE, FALSE, 0x05A0), window.x, window.y, window.w, window.h, DMA);
+	VDP_clearTextAreaEx(BG_A, TILE_ATTR_FULL(TEXT_PAL, FALSE, FALSE, FALSE, 0x05A0), window.x, window.y, window.w, window.h, DMA);
 }
 
 void VN_textStart() {
@@ -436,7 +439,7 @@ void VN_cursor(const SpriteDefinition *sprite) {
 	
 	if (!sprite) return;
 	
-	window.cursor = SPR_addSprite(sprite, 0, 0, TILE_ATTR(PAL0, 1, FALSE, FALSE));
+	window.cursor = SPR_addSprite(sprite, 0, 0, TILE_ATTR(TEXT_PAL, 1, FALSE, FALSE));
 	SPR_setVisibility(window.cursor, HIDDEN);
-	VDP_setPalette(PAL0, (u16*) sprite->palette->data);
+	VDP_setPalette(TEXT_PAL, (u16*) sprite->palette->data);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choice4genesis",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "A ChoiceScript clone that generates SGDK-compatible C source for the Sega Genesis ",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Make the background use pallette 0, and text use palette 1, so the background is shown correctly.
That way, color 0 of the background is shown correctly.
This fixes #77 