### PR TITLE
Harden menu against crashing

### DIFF
--- a/base/src/vn_engine.c
+++ b/base/src/vn_engine.c
@@ -210,7 +210,7 @@ void VN_init() {
 	XGM_setForceDelayDMA(TRUE);
 
 	VDP_setTextPalette(TEXT_PAL);
-	VDP_drawText("choice4genesis v0.14.3", 17, 27);
+	VDP_drawText("choice4genesis v0.14.4", 17, 27);
 }
 
 

--- a/generator/ui.js
+++ b/generator/ui.js
@@ -29,7 +29,15 @@ const showMenu = async (commandLine, executeCommands) => {
 		
 	projectNames.forEach(projectName => menu.addItem(projectName, () => {
 		commandLine.project = projectName;
-		return executeCommands();
+		return executeCommands()
+			.then(data => {
+				console.log(chalk.green('<< Press ENTER to return to menu >>'));
+				return data;
+			})
+			.catch(e => {
+				console.error(`Error while compiling ${projectName}`, e);
+				console.error(chalk.red('<< Press ENTER to return to menu >>'));
+			});
 	}));
 			
 	menu.start();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "choice4genesis",
-  "version": "0.14.3",
+  "version": "0.14.4",
   "description": "A ChoiceScript clone that generates SGDK-compatible C source for the Sega Genesis ",
   "main": "index.js",
   "targets": {


### PR DESCRIPTION
Keep the menu running even if the invoked compiler crashes badly.
This fixes #113 